### PR TITLE
Avoid resetting playback when toggling GlobalPlayer

### DIFF
--- a/src/components/GlobalPlayer.tsx
+++ b/src/components/GlobalPlayer.tsx
@@ -9,15 +9,30 @@ export default function GlobalPlayer() {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [progress, setProgress] = useState(0);
 
+  // Charge une nouvelle source audio uniquement lorsque la piste change
   useEffect(() => {
     if (!audioRef.current || !current) return;
     audioRef.current.src = current.audio;
     if (isPlaying) {
+      // Lecture automatique si on est censé jouer
       audioRef.current.play();
     } else {
+      // Mise en pause sinon
       audioRef.current.pause();
     }
-  }, [current, isPlaying]);
+  }, [current]);
+
+  // Gère l'état lecture/pause sans réinitialiser la source
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    if (isPlaying) {
+      audio.play();
+    } else {
+      audio.pause();
+    }
+  }, [isPlaying]);
 
   useEffect(() => {
     const audio = audioRef.current;


### PR DESCRIPTION
## Summary
- prevent audio source from resetting on play/pause toggles in GlobalPlayer
- keep playback state changes separate from track loading

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: asks for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ef8ba258832d95308d588082b717