### PR TITLE
Add basic auth context for account creation and login

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { AudioPlayerProvider } from "@/context/AudioPlayerContext";
 import GlobalAudioPlayer from "@/components/GlobalAudioPlayer";
 import NavBar from "@/components/Navbar";
+import { AuthProvider } from "@/context/AuthContext";
 
 export const metadata: Metadata = {
   title: "Beatmakerz",
@@ -17,15 +18,17 @@ export default function RootLayout({
   return (
     <html lang="fr" suppressHydrationWarning>
       <body>
-        <AudioPlayerProvider>
-          <header>
-            <NavBar />
-          </header>
+        <AuthProvider>
+          <AudioPlayerProvider>
+            <header>
+              <NavBar />
+            </header>
 
-          {children}
+            {children}
 
-          <GlobalAudioPlayer />
-        </AudioPlayerProvider>
+            <GlobalAudioPlayer />
+          </AudioPlayerProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/web/profil/page.tsx
+++ b/src/app/web/profil/page.tsx
@@ -3,11 +3,13 @@
 import React, { useState, FormEvent, ChangeEvent } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
 
 const Profil: React.FC = () => {
   // Mode "Se connecter" / "S'inscrire"
   const [isLogin, setIsLogin] = useState<boolean>(true);
   const router = useRouter();
+  const { login, signup } = useAuth();
 
   // États des formulaires
   const [loginData, setLoginData] = useState({ username: "", password: "" });
@@ -21,14 +23,22 @@ const Profil: React.FC = () => {
 
   const handleLoginSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // TODO: logique de connexion
-    router.push("/"); // Redirection vers la home
+    const success = login(loginData.username, loginData.password);
+    if (success) {
+      router.push("/");
+    } else {
+      alert("Identifiants invalides");
+    }
   };
 
   const handleSignupSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // TODO: logique d'inscription
-    router.push("/"); // Redirection vers la home
+    const success = signup(signupData.username, signupData.password);
+    if (success) {
+      router.push("/");
+    } else {
+      alert("Nom d'utilisateur déjà existant");
+    }
   };
 
   return (

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface AuthContextType {
+  user: string | null;
+  login: (username: string, password: string) => boolean;
+  signup: (username: string, password: string) => boolean;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedUser = typeof window !== "undefined" ? localStorage.getItem("currentUser") : null;
+    if (storedUser) {
+      setUser(storedUser);
+    }
+  }, []);
+
+  const login = (username: string, password: string) => {
+    if (typeof window === "undefined") return false;
+    const users = JSON.parse(localStorage.getItem("users") || "{}");
+    if (users[username] && users[username] === password) {
+      localStorage.setItem("currentUser", username);
+      setUser(username);
+      return true;
+    }
+    return false;
+  };
+
+  const signup = (username: string, password: string) => {
+    if (typeof window === "undefined") return false;
+    const users = JSON.parse(localStorage.getItem("users") || "{}");
+    if (users[username]) {
+      return false;
+    }
+    users[username] = password;
+    localStorage.setItem("users", JSON.stringify(users));
+    localStorage.setItem("currentUser", username);
+    setUser(username);
+    return true;
+  };
+
+  const logout = () => {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem("currentUser");
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+};
+


### PR DESCRIPTION
## Summary
- add client-side AuthContext with localStorage-backed login, signup, and logout
- wrap application in AuthProvider to expose auth state
- enable profile page forms to create accounts and authenticate users

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f1ddab78832d90851ce5ef220568