### PR TITLE
Fix provider layout and streamline BeatCard props

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,21 +19,19 @@ export default function RootLayout({
   return (
     <html lang="fr" suppressHydrationWarning>
       <body>
-
         <CartProvider>
+          <AuthProvider>
+            <AudioPlayerProvider>
+              <header>
+                <NavBar />
+              </header>
 
-        <AuthProvider>
+              {children}
 
-          <AudioPlayerProvider>
-            <header>
-              <NavBar />
-            </header>
-
-            {children}
-
-            <GlobalAudioPlayer />
-          </AudioPlayerProvider>
-
+              <GlobalAudioPlayer />
+            </AudioPlayerProvider>
+          </AuthProvider>
+        </CartProvider>
       </body>
     </html>
   );

--- a/src/components/BeatCard.tsx
+++ b/src/components/BeatCard.tsx
@@ -12,7 +12,7 @@ export type BeatCardProps = {
   genre: string;
   bpm: number;
   keySig: string;
-  tag?: Tag | null;
+  tag?: Tag;
   isCurrent: boolean;
   isPlaying: boolean;
   onPlayPause: () => void;


### PR DESCRIPTION
## Summary
- close nested providers in RootLayout to restore valid JSX structure
- simplify BeatCard's tag prop typing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint configuration prompt)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a6f5017fd8832d8e66102d36a998c4