### PR TITLE
feat: add account page and navigation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -79,6 +79,11 @@ module.exports = {
         permanent: true,
       },
       {
+        source: "/account",
+        destination: "/web/account",
+        permanent: true,
+      },
+      {
         source: "/catalogue",
         destination: "/web/catalogue",
         permanent: true,

--- a/src/app/web/account/page.tsx
+++ b/src/app/web/account/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React from "react";
+import { useAuth } from "@/context/AuthContext";
+import { useRouter } from "next/navigation";
+
+const AccountPage: React.FC = () => {
+  const { user, logout } = useAuth();
+  const router = useRouter();
+
+  if (!user) {
+    if (typeof window !== "undefined") {
+      router.push("/profil");
+    }
+    return null;
+  }
+
+  const handleLogout = () => {
+    logout();
+    router.push("/");
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-r from-black via-[#1A1530] to-[#000000] text-white p-4">
+      <h1 className="text-2xl mb-4">Bonjour {user}</h1>
+      <button
+        onClick={handleLogout}
+        className="bg-[#401a87] hover:bg-[#5e2ea4] transition-colors text-white font-semibold py-2 px-4 rounded-full"
+      >
+        Se déconnecter
+      </button>
+    </div>
+  );
+};
+
+export default AccountPage;
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,6 +13,7 @@ import {
 import SearchBar from "./SearchBar";
 import CartSideBar from "./CartSideBar";
 import { useCart } from "@/context/CartContext";
+import { useAuth } from "@/context/AuthContext";
 
 const AnimatedTwoBarsToggle = ({
   isOpen,
@@ -125,6 +126,7 @@ const NavBar = () => {
   const [isCartOpen, setIsCartOpen] = useState(false);
 
   const { totalItems } = useCart();
+  const { user } = useAuth();
 
   const overlayRef = useRef<HTMLDivElement>(null);
 
@@ -175,7 +177,7 @@ const NavBar = () => {
 
           <div className="flex items-center space-x-2 ml-6">
             <Link
-              href="/profil"
+              href={user ? "/account" : "/profil"}
               className="p-1 rounded-full border border-white/20"
             >
               <img src="/img/profil.png" alt="Profil" className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- add an account page with logout and redirect when no session
- route `/account` to `/web/account`
- route profile button to account page when user is logged in

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and @next/next/no-img-element warnings/errors in existing files)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a86152d5d4832dab10320c0fa6b281