### PR TITLE
feat: enable dynamic cart from beat cards

### DIFF
--- a/src/app/web/catalogue/page.tsx
+++ b/src/app/web/catalogue/page.tsx
@@ -443,16 +443,17 @@ export default function CataloguePage() {
                   {currentBeats.map((b) => (
                     <BeatCard
                       key={b.id}
+                      id={b.id}
                       name={b.name}
                       artist={b.artist}
                       genre={b.genre}
                       bpm={b.bpm}
                       keySig={b.key}
+                      price={b.price}
                       tag={b.tag ?? undefined}
                       isCurrent={track?.id === b.id}
                       isPlaying={isPlaying}
                       onPlayPause={() => onPlay(b)}
-                      onAdd={() => addItem({ id: b.id, name: b.name, price: b.price })}
                       onFav={() => {}}
                       onMore={() => {}}
                     />

--- a/src/components/BeatCard.tsx
+++ b/src/components/BeatCard.tsx
@@ -3,15 +3,18 @@
 import { motion } from "framer-motion";
 import { Music2, Sparkles } from "lucide-react";
 import ActionBar from "./ActionBar";
+import { useCart } from "@/context/CartContext";
 
 export type Tag = "Tendance" | "Nouveau" | "Populaire";
 
 export type BeatCardProps = {
+  id: number | string;
   name: string;
   artist: string;
   genre: string;
   bpm: number;
   keySig: string;
+  price: number;
   tag?: Tag;
   isCurrent: boolean;
   isPlaying: boolean;
@@ -25,11 +28,13 @@ const chip =
   "inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[0.65rem] text-zinc-400 align-middle";
 
 export default function BeatCard({
+  id,
   name,
   artist,
   genre,
   bpm,
   keySig,
+  price,
   tag,
   isCurrent,
   isPlaying,
@@ -38,6 +43,12 @@ export default function BeatCard({
   onFav,
   onMore,
 }: BeatCardProps) {
+  const { addItem } = useCart();
+
+  const handleAdd = () => {
+    addItem({ id, name, price });
+    onAdd?.();
+  };
   return (
     <motion.div
       layout
@@ -85,7 +96,7 @@ export default function BeatCard({
           isCurrent={isCurrent}
           isPlaying={isPlaying}
           onPlayPause={onPlayPause}
-          onAdd={onAdd}
+           onAdd={handleAdd}
           onFav={onFav}
           onMore={onMore}
         />


### PR DESCRIPTION
## Summary
- connect `BeatCard` component to cart context so the add button pushes items into cart
- adjust catalogue page to provide id and price for each beat card

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8611e6a80832db2ff0608f5b7c6fe